### PR TITLE
Add missing f-string and update bool pattern for manual saves

### DIFF
--- a/re-enable_achievements.py
+++ b/re-enable_achievements.py
@@ -140,7 +140,7 @@ def patch_quick_autosaves(folder: Path) -> None:
                 if idx == -1:
                     break
 
-                bool_pattern = b"\x00\x0D\x00Bool\x00"
+                bool_pattern = b"\x00\x0D\x00Bool"
                 start = idx + len(b"bIsAchievementsDisabled")
 
                 if data[start:start + len(bool_pattern)] == bool_pattern:

--- a/re-enable_achievements.py
+++ b/re-enable_achievements.py
@@ -121,7 +121,7 @@ def patch_quick_autosaves(folder: Path) -> None:
                 idx = end_idx
 
             if patched:
-                shutil.copy2(file, file.with_suffix(file.suffix + ".BAK{int(time.time())}"))
+                shutil.copy2(file, file.with_suffix(file.suffix + f".BAK{int(time.time())}"))
                 write_file(file, data)
             else:
                 print("❌ No patch needed or pattern not found.")


### PR DESCRIPTION
`133c81c` fixes some backup files having the literal suffix `BAK{int(time.time())}`

`7c280b0` will probably fix #4; Autosaves have 2 bytes following "Bool", manual saves only have 1:

_placeholder file names, since the actual ones are insanely long_
```shell
hexdiff autosave.sav  autosave.sav.BAK1746820773
   offset      0 1 2 3 4 5 6 7 01234567       offset      0 1 2 3 4 5 6 7 01234567
0x0000000000  4756415303000000 GVAS....    0x0000000000  4756415303000000 GVAS....
...
0x00000a3d18  6f6f6c0000436861 ool..Cha    0x00000a3d18  6f6f6c0001436861 ool..Cha
0x00000a3d20  7261637449641005 ractId..    0x00000a3d20  7261637449641005 ractId..
...
```

```shell
hexdiff manual_save.sav manual_save.sav.BAK1746821838
   offset      0 1 2 3 4 5 6 7 01234567       offset      0 1 2 3 4 5 6 7 01234567
0x0000000000  4756415303000000 GVAS....    0x0000000000  4756415303000000 GVAS....
...
0x00000a31c0  426f6f6c00436861 Bool.Cha    0x00000a31c0  426f6f6c01436861 Bool.Cha
0x00000a31c8  7261637449641005 ractId..    0x00000a31c8  7261637449641005 ractId..
...
```